### PR TITLE
Bump node from 12.18 to 14.17

### DIFF
--- a/linux-amd64.Dockerfile
+++ b/linux-amd64.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18-alpine AS builder
+FROM node:14.17-alpine AS builder
 RUN apk add --no-cache curl
 ARG VERSION
 ENV COMMIT_TAG=${VERSION}

--- a/linux-arm-v7.Dockerfile
+++ b/linux-arm-v7.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18-alpine AS builder
+FROM node:14.17-alpine AS builder
 RUN apk add --no-cache curl build-base python3 python2 sqlite
 ARG VERSION
 ENV COMMIT_TAG=${VERSION}

--- a/linux-arm64.Dockerfile
+++ b/linux-arm64.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18-alpine AS builder
+FROM node:14.17-alpine AS builder
 RUN apk add --no-cache curl build-base python3 python2 sqlite
 ARG VERSION
 ENV COMMIT_TAG=${VERSION}


### PR DESCRIPTION
Node 14.17+ is now required (see sct/overseerr#1792)